### PR TITLE
Add `hymenaios-io/hymenaios` Service example

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -289,6 +289,20 @@ service:
           value: Bearer <API_TOKEN>
 ```
 
+## hymenaios-io/Hymenaios
+Source: https://github.com/hymenaios-io/Hymenaios
+```yaml
+service:
+  hymenaios-io/Hymenaios:
+    type: github
+    url: hymenaios-io/Hymenaios
+    web_url: https://github.com/hymenaios-io/Hymenaios/blob/master/CHANGELOG.md
+    icon: https://github.com/hymenaios-io/Hymenaios/raw/master/web/ui/static/favicon.svg
+    deployed_version:
+      url: https://hymenaios.example.io/api/v1/version
+      json: version
+```
+
 ## louislam/uptime-kuma
 Source: https://github.com/louislam/uptime-kuma
 ```yaml


### PR DESCRIPTION
Added `/api/v1/version` with https://github.com/hymenaios-io/Hymenaios/pull/19. Just waiting on a build before we merge this