### PR TITLE
Remove superfluous `accept` header from mailcow

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -326,7 +326,7 @@ service:
     url: mailcow/mailcow-dockerized
     web_url: https://github.com/mailcow/mailcow-dockerized/releases/tag/{{ version }}
     semantic_versioning: false
-    regex_version: ^[0-9-]+$
+    regex_version: ^[0-9-]+[a-z]?$
     icon: https://raw.githubusercontent.com/mailcow/mailcow-dockerized/master/data/web/img/cow_mailcow.svg
     deployed_version:
       url: https://mailcow.example.io/api/v1/get/status/version

--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -333,8 +333,6 @@ service:
       headers:
         - key: X-API-Key
           value: <ReadOnly-API-Key>
-        - key: accept
-          value: application/json
       json: version
 ```
 
@@ -521,7 +519,7 @@ service:
         username: <username>
         password: <password>
       json: value
-      regex: v?([0-9.]+)
+      regex: v([0-9.]+)
 ```
 
 ## requarks/wiki


### PR DESCRIPTION
also revert Rancher `deployed_version` regex to `v([0-9.]+)`

FYI @larsl-net. Reverting regex as it was only suggested because I misread the changes and thought it was for Matomo where the tag doesn't have the `v`. Removing this `accept` header as mine works without it (can be seen on the demo page. Those *.example.io's are going to my own services, I've just setup DNS on the demo server to resolve *.example.io to my services in order to not advertise their addresses)