### PR TITLE
release(0.29.0): use `headers`, not `custom_headers`

### DIFF
--- a/content/en/docs/Config/webhook.md
+++ b/content/en/docs/Config/webhook.md
@@ -13,7 +13,7 @@ that appears, set the 'Webhook Service' to 'GitHub' and save the changes to get 
 the URL and Key for this WebHook.
 
 {{< alert title="Note" >}}
-Environment variables in the format ${ENV_VAR} can be used in the `custom_headers.*.key`, `custom_headers.*.value`, `secret` and `url` fields.
+Environment variables in the format ${ENV_VAR} can be used in the `headers.*.key`, `headers.*.value`, `secret` and `url` fields.
 {{< /alert >}}
 
 config.yml:
@@ -26,7 +26,7 @@ webhook:
     url: https://WEBHOOK_URL    # WebHook URL to send to
     allow_invalid_certs: false  # Accept invalid HTTPS certs/not
     secret: SECRET              # WebHook Key/Secret
-    custom_headers:             # Custom headers to give the WebHook (could be a param for the WebHook that's unique to the Service)
+    headers:             # Custom headers to give the WebHook (could be a param for the WebHook that's unique to the Service)
       - key: fizz
         value: bang
     desired_status_code: 201    # Status code to use indicating a success. Using 0 will accept any 2XX status code
@@ -36,8 +36,8 @@ webhook:
     silent_fails: false         # Whether to notify the service's notifiers if max_tries fails occur
 ```
 
-### custom_headers
-Say you had one script that could handle a few different services, `custom_headers` could be used to give the receiver of the WebHook a param that tells it which service to update.
+### headers
+Say you had one script that could handle a few different services, `headers` could be used to give the receiver of the WebHook a param that tells it which service to update.
 If using something like [adnanh/webhook](https://github.com/adnanh/webhook), you can setup params for your WebHook with something like:
 
 ```yaml
@@ -54,7 +54,7 @@ Then, in Argus' `config.yml`
 ```yaml
     webhook:
       some_name:
-        custom_headers:
+        headers:
           - key: SOMETHING
             value: 'foo'
           - key: VERSION

--- a/content/en/docs/Getting started/faq.md
+++ b/content/en/docs/Getting started/faq.md
@@ -42,7 +42,7 @@ Environment variables in the format `${ENV_VAR}` (e.g. 'abc ${AUTH_TOKEN}'  or j
 * notify.\*.options.\*
 * notify.\*.params.\*
 * notify.\*.url_fields.\*
-* webhook.\*.custom_headers.\*.key
-* webhook.\*.custom_headers.\*.value
+* webhook.\*.headers.\*.key
+* webhook.\*.headers.\*.value
 * webhook.\*.secret
 * webhook.\*.url


### PR DESCRIPTION
[664f24e](https://github.com/release-argus/Argus/commit/664f24e7028387703d76243676b797e6c3c153fd) renamed `custom_headers` to `headers` (and added auto-conversions to this new key)