### PR TITLE
examples: add nginx proxy manager

### DIFF
--- a/content/en/docs/Examples/services.md
+++ b/content/en/docs/Examples/services.md
@@ -1097,6 +1097,25 @@ service:
       icon: https://github.com/nextcloud/server/raw/master/core/img/favicon.png
 ```
 
+## NginxProxyManager/nginx-proxy-manager
+Source: https://github.com/NginxProxyManager/nginx-proxy-manager
+```yaml
+service:
+  NginxProxyManager/nginx-proxy-manager:
+    latest_version:
+      type: github
+      url: NginxProxyManager/nginx-proxy-manager
+      url_commands:
+        - type: regex
+          regex: v?([0-9.]+)$
+    deployed_version:
+      url: http://npm.example.com:81/api/version/check
+      regex: '"current"\s*:\s*"v?([0-9.]+)"'
+    dashboard:
+      icon: https://raw.githubusercontent.com/NginxProxyManager/nginx-proxy-manager/develop/docs/src/public/icon.png
+      web_url: https://github.com/NginxProxyManager/nginx-proxy-manager/releases/tag/v{{ version }}
+```
+
 ## OliveTin/OliveTin
 Source: https://github.com/OliveTin/OliveTin
 ```yaml


### PR DESCRIPTION
Adds an example service configuration for Nginx Proxy Manager.

This uses:
- GitHub releases for latest_version
- /api/version/check for deployed_version
- The official icon from the Nginx Proxy Manager repository

I tested the deployed_version endpoint locally and it returns JSON like:
{"current":"v2.14.0","latest":"v2.15.1","update_available":true}